### PR TITLE
[WIP]【再】新規登録とログイン画面の見た目調整

### DIFF
--- a/react-app/src/components/Login.tsx
+++ b/react-app/src/components/Login.tsx
@@ -1,8 +1,8 @@
 import { FC, useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { BaseURL } from "../utilities/base_url";
-import { HelmetProvider } from "react-helmet-async";
 import { Link, useNavigate } from "react-router-dom";
+import TitleIcon from "../../public/chocolog.svg";
 
 type LoginForm = {
   email: string;
@@ -49,10 +49,19 @@ const Login: FC = () => {
 
   return (
     <>
-      <HelmetProvider>{/* Helmet content... */}</HelmetProvider>
-      <div className="flex justify-center items-center min-h-screen bg-[#9debf6]">
-        <div className="w-full max-w-md p-8 rounded-2xl bg-[#9debf6]">
-          <h1 className="text-3xl text-center mb-10 text-customBrown font-semibold font-roundedMplus">
+      <div className="flex justify-center min-h-screen bg-[#74ecff]">
+        <div className="w-90% max-w-md rounded-2xl bg-[#74ecff]">
+          <div className="text-center text-2xl font-bold">
+                <img
+                  src={TitleIcon}
+                  alt="Chocolog"
+                  width={270}
+                  height={270}
+                  style={{ color: "red", marginBottom: "0rem", display: 'block', marginLeft: 'auto', marginRight: 'auto' }} // This centers the image
+                />
+          </div>
+          
+          <h1 className="text-2xl text-center mb-10 text-customBrown font-bold font-roundedMplus">
             ログイン
           </h1>
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-10">
@@ -68,9 +77,10 @@ const Login: FC = () => {
                   required: true,
                   pattern: mailadressCheck,
                 })}
-                className="w-full px-4 py-2 mt-2 border border-gray-200 rounded-xl text-lg focus:ring-customBrown focus:border-customBrown bg-customSkyblue"
+                className="w-full px-4 py-2 mt-2 border border-gray-200 rounded-xl text-lg focus:outline-none bg-customSkyblue"
                 id="email"
                 type="text"
+                placeholder="Email"
               />
               {errors.email && (
                 <p className="text-red-600">メールアドレスは必須です。</p>
@@ -85,9 +95,10 @@ const Login: FC = () => {
               </label>
               <input
                 {...register("password", { required: true })}
-                className="w-full px-4 py-2 mt-2 border border-gray-200 rounded-xl text-lg focus:ring-customBrown focus:border-customBrown bg-customSkyblue"
+                className="w-full px-4 py-2 mt-2 border border-gray-200 rounded-xl text-lg focus:outline-none bg-customSkyblue"
                 id="password"
                 type="password"
+                placeholder="Password"
               />
               {errors.password && (
                 <p className="text-red-600">パスワードは必須です。</p>

--- a/react-app/src/components/Signup.tsx
+++ b/react-app/src/components/Signup.tsx
@@ -53,32 +53,30 @@ const Signup: FC = () => {
   };
   return (
     <>
-      <div className="flex justify-center items-center bg-cyan-200 min-h-screen">
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-10">
-          <div className="flex flex-col text-gray-500">
-            <div className="flex justify-center items-end mb-10 text-center text-2xl font-bold">
+      <div className="flex justify-center items-center bg-[#74ecff] min-h-screen">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-10" style={{ width: '380px' }}>
+          <div className="flex flex-col text-customBrown font-roundedMplus">
+            <div className="text-center text-2xl font-bold">
               <img
                 src={TitleIcon}
-                alt=""
-                width={70}
-                height={70}
-                style={{ color: "red" }}
+                alt="Chocolog"
+                width={270}
+                height={270}
+                style={{ color: "red", marginBottom: "0rem", display: 'block', marginLeft: 'auto', marginRight: 'auto' }} // This centers the image
               />
-              <h1 className="text-7xl text-gray-500">Choco</h1>
-              <h1 className="text-7xl text-gray-500">log</h1>
             </div>
-
+  
             <div className="text-center text-2xl font-bold">
               新規登録
             </div>
 
-            <label htmlFor="username" className="font-bold text-left mt-10">
+            <label htmlFor="username" className="text-lg text-left font-semibold mt-2">
               ユーザー名
             </label>
             <input
               id="username"
               type="text"
-              placeholder="username"
+              placeholder="Username"
               {...register("username", {
                 required: "ユーザーネームは必須です",
                 pattern: {
@@ -87,13 +85,13 @@ const Signup: FC = () => {
                     "ユーザーネームは 半角大文字小文字 英数字と_.- 3文字〜16文字",
                 },
               })}
-              className="bg-cyan-50 text-xl mt-2 p-2.5 focus:outline-none rounded-lg"
+              className="bg-cyan-50 text-lg mt-1 p-2.5 focus:outline-none rounded-xl"
             />
             {errors.username && (
               <div className="text-red-600">{errors.username.message}</div>
             )}
 
-            <label htmlFor="email" className="text-left font-bold mt-10">
+            <label htmlFor="email" className="text-lg text-left font-semibold mt-10">
               メールアドレス
             </label>
             <input
@@ -107,14 +105,14 @@ const Signup: FC = () => {
                   message: "メールアドレスを入力し直してください",
                 },
               })}
-              className="bg-cyan-50 text-xl mt-2 p-2.5 focus:outline-none rounded-lg"
+              className="bg-cyan-50 text-lg mt-1 p-2.5 focus:outline-none rounded-xl"
             />
             {errors.email && (
               <div className="text-red-600">{errors.email.message}</div>
             )}
 
 
-            <label htmlFor="password" className="text-left font-bold mt-10">
+            <label htmlFor="password" className="text-lg text-left font-semibold mt-10">
               パスワード
             </label>
             <input
@@ -124,14 +122,14 @@ const Signup: FC = () => {
               {...register("password", {
                 required: "パスワードは必須です",
               })}
-              className="bg-cyan-50 text-xl mt-2 p-2.5 focus:outline-none rounded-lg"
+              className="bg-cyan-50 text-lg mt-1 p-2.5 focus:outline-none rounded-xl"
             />
             {errors.password && (
               <div className="text-red-600">{errors.password.message}</div>
             )}
 
 
-            <label htmlFor="passwordConfirm" className="text-left font-bold mt-10">
+            <label htmlFor="passwordConfirm" className="text-lg text-left font-bold mt-10">
               パスワード（確認用）
             </label>
             <input
@@ -142,10 +140,10 @@ const Signup: FC = () => {
                 validate: (value) =>
                   value === password || "パスワードが一致しません",
               })}
-              className="bg-cyan-50 text-xl mt-2 p-2.5 focus:outline-none rounded-lg"
+              className="bg-cyan-50 text-lg mt-1 p-2.5 focus:outline-none rounded-xl"
             />
 
-            <div className="text-center font-bold mt-10 mb-10">
+            <div className="text-lg text-center font-bold mt-8 mb-8">
               <Link to="/login" className="hover:underline">
                 ログインはこちら
               </Link>
@@ -154,7 +152,7 @@ const Signup: FC = () => {
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="w-1/4 focus:outline-none bg-yellow-400 hover:bg-yellow-500 font-bold p-3 rounded-lg">
+                className="w-1/3 focus:outline-none bg-yellow-400 hover:bg-yellow-500 text-lg font-semibold p-3 rounded-xl">
                 {isSubmitting ? "登録中..." : "新規登録"}
               </button>
             </div>


### PR DESCRIPTION
### やったこと
ロゴを入れる
フォントを揃える（Figmaで使用されていたものをカスタム）
入力フォームのデザインを合わせる
ロゴの背景の色に合わせる（色の境目が気になったためロゴの背景の方にそろえた。前の方が良ければ教えてください）

### 見た目
![image](https://github.com/hackathon2024spring/front/assets/146703580/d826eb5a-5849-4bb8-bea6-86bd84476586)
![image](https://github.com/hackathon2024spring/front/assets/146703580/52402fb5-fa05-4f6c-8614-a85cf002a8c9)

### 特記事項
新規登録のページが、少し縦長なので、パソコンサイズだと「新規登録」のボタンが切れている。
画面表示90％くらいでちょうどよいので、必要なら修正。

### チェック項目
特になし