### PR TITLE
[WIP]カレンダーヘッダーからユーザー詳細ページへ遷移できるようにした

### DIFF
--- a/react-app/src/components/CalendarHeader.tsx
+++ b/react-app/src/components/CalendarHeader.tsx
@@ -18,10 +18,6 @@ const CalendarHeader: FC = () => {
     setMonthIndex(monthIndex + 1);
   };
 
-  const handleReset = () => {
-    setMonthIndex(dayjs().month());
-  };
-
   const handleUserClick = () => {
     navigate('/user'); // Function to navigate to settings page
   };

--- a/react-app/src/components/CalendarHeader.tsx
+++ b/react-app/src/components/CalendarHeader.tsx
@@ -22,6 +22,10 @@ const CalendarHeader: FC = () => {
     setMonthIndex(dayjs().month());
   };
 
+  const handleUserClick = () => {
+    navigate('/user'); // Function to navigate to settings page
+  };
+
   const handleSettingsClick = () => {
     navigate('/exercises_setting'); // Function to navigate to settings page
   };
@@ -40,9 +44,9 @@ const CalendarHeader: FC = () => {
           <span className="activity-text">✨足踏み運動をする✨</span>
         </div>
         <div className="flex">
-          <img src="/images/icon-account.png" alt="Account" className="icon-account" />
+          <img src="/images/icon-account.png" alt="Account" className="icon-account mt-5 mx-4 w-14 h-14" onClick={handleUserClick} />
           {/* Add onClick handler to settings icon */}
-          <img src="/images/icon-settings.png" alt="Settings" className="icon-settings" onClick={handleSettingsClick} />
+          <img src="/images/icon-settings.png" alt="Settings" className="icon-settings mt-5 w-12 h-12" onClick={handleSettingsClick} />
         </div>
       </div>
       <header className="flex items-center justify-between">


### PR DESCRIPTION
### やったこと
カレンダーヘッダーからユーザー詳細ページへ遷移できるようにした
ヘッダーのアイコンのスタイル調整

### 見た目
[![Image from Gyazo](https://i.gyazo.com/f036c1daefe5cf3f1770a1ea61e8a6f7.gif)](https://gyazo.com/f036c1daefe5cf3f1770a1ea61e8a6f7)

### 特記事項
なし

### チェック項目
なし