### PR TITLE
[WIP]カレンダーの見た目調整とexerciseページへのルーティンング定義

### DIFF
--- a/react-app/src/components/Calendar.tsx
+++ b/react-app/src/components/Calendar.tsx
@@ -16,7 +16,7 @@ const Calendar: FC = () => {
   return (
     <>
       {showEventModal && <EventModal />}
-      <div className="h-screen flex flex-col bg-[#9debf6] font-roundedMplus">
+      <div className="h-screen flex flex-col items-center bg-[#9debf6] font-roundedMplus">
         <CalendarHeader />
         <WeekDaysLabels />
         {/* Pass the current month index to the Month component */}
@@ -31,7 +31,7 @@ const WeekDaysLabels: FC = () => {
   const weekDays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
   return (
-    <div className="grid grid-cols-7 text-center border-b font-roundedMplus font-bold">
+    <div className="flex justify-center grid grid-cols-7 text-center border-b font-roundedMplus font-bold w-2/3">
       {weekDays.map((day, index) => (
         <div
           key={day}

--- a/react-app/src/components/Day.tsx
+++ b/react-app/src/components/Day.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useContext, useEffect, useState } from "react";
+import React, { FC } from "react";
 import dayjs from "dayjs";
-import GlobalContext, { CalendarEvent } from "../context/GlobalContext";
+import { useNavigate } from "react-router-dom";
 
 interface DayProps {
   day: dayjs.Dayjs;
@@ -8,16 +8,8 @@ interface DayProps {
   currentMonthIndex: number; // Add this line
 }
 
-const Day: FC<DayProps> = ({ day, rowIdx, currentMonthIndex }) => {
-  const [dayEvents, setDayEvents] = useState<CalendarEvent[]>([]);
-  const { setDaySelected, setShowEventModal, savedEvents, setSelectedEvent } = useContext(GlobalContext);
-
-  useEffect(() => {
-    const events = savedEvents.filter(evt =>
-      dayjs(evt.day).format("DD-MM-YY") === day.format("DD-MM-YY")
-    );
-    setDayEvents(events);
-  }, [savedEvents, day]);
+const Day: FC<DayProps> = ({ day, currentMonthIndex }) => {
+  const navigate = useNavigate();
 
   const isCurrentMonth = day.month() === currentMonthIndex;
 
@@ -40,29 +32,18 @@ const Day: FC<DayProps> = ({ day, rowIdx, currentMonthIndex }) => {
 
   const dayNumberClasses = `text-lg font-bold my-1 ${getCurrentDayClass()} ${dayClasses} ${nonCurrentMonthClass}`;
 
+  const handleExerciseClick = () => {
+    navigate('/exercise');
+  };
+
   return (
-    <div className={`border border-borderDivider flex flex-col rounded-none overflow-hidden`}>
+    <div className="border border-borderDivider flex flex-col rounded-none overflow-hidden">
       <header className="bg-customSkyblue p-1 flex justify-center"> {/* Align to center */}
         <p className={dayNumberClasses}>
           {day.format("D")} {/* Remove leading zero for single-digit dates */}
         </p>
       </header>
-      <div
-        className="bg-customSkyblue p-1 flex-1 cursor-pointer p-1"
-        onClick={() => {
-          setDaySelected(day);
-          setShowEventModal(true);
-        }}
-      >
-        {dayEvents.map((evt, idx) => (
-          <div
-            key={idx}
-            onClick={() => setSelectedEvent(evt)}
-            className="bg-neutral-200 p-1 mr-3 text-gray-600 text-sm rounded mb-1 truncate"
-          >
-            {evt.title}
-          </div>
-        ))}
+      <div onClick={handleExerciseClick} className="bg-customSkyblue p-1 flex-1 cursor-pointer p-1">
       </div>
     </div>
   );

--- a/react-app/src/components/Month.tsx
+++ b/react-app/src/components/Month.tsx
@@ -9,7 +9,7 @@ interface MonthProps {
 
 const Month: FC<MonthProps> = ({ month, currentMonthIndex }) => {
   return (
-    <div className="flex-1 grid grid-cols-7 gap-1.5 p-1.5">
+    <div className="flex-1 grid grid-cols-7 gap-1.5 p-1.5 w-2/3 mb-12">
       {month.map((row, i) => (
         <React.Fragment key={i}>
           {row.map((day, idx) => (


### PR DESCRIPTION
### やったこと
カレンダーの見た目調整
カレンダーのマス目をクリックするとexerciseページへ遷移するようにした

### 見た目
[![Image from Gyazo](https://i.gyazo.com/6f229e4acdf24b29871dfccd17c72910.gif)](https://gyazo.com/6f229e4acdf24b29871dfccd17c72910)

### 特記事項
最終的にそれぞれの日付と紐づくexerciseページに遷移する必要あると思いますが、一旦共通のページに遷移するようにしてます

### チェック項目
なし