### PR TITLE
[WIP]カレンダーページのレスポンシブ対応

### DIFF
--- a/react-app/src/components/Calendar.tsx
+++ b/react-app/src/components/Calendar.tsx
@@ -14,7 +14,6 @@ const Calendar: FC = () => {
   const [message, setMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    // localStorageからmonthIndexを読み込む
     const savedMonthIndex = localStorage.getItem('monthIndex');
     if (savedMonthIndex !== null) {
       setMonthIndex(parseInt(savedMonthIndex, 10));
@@ -28,8 +27,6 @@ const Calendar: FC = () => {
   useEffect(() => {
     if (state?.message) {
       setMessage(state.message);
-
-      // 履歴状態からメッセージを削除してリロード時に表示されないようにする
       navigate(location.pathname, { replace: true, state: {} });
     }
   }, [state, navigate, location.pathname]);
@@ -38,7 +35,6 @@ const Calendar: FC = () => {
     if (message) {
       const timer = setTimeout(() => {
         setMessage(null);
-        // monthIndexをlocalStorageに保存
         localStorage.setItem('monthIndex', monthIndex.toString());
         window.location.reload();
       }, 2000);
@@ -53,7 +49,7 @@ const Calendar: FC = () => {
           {message}
         </div>
       )}
-      <div className="h-screen flex flex-col items-center bg-[#9debf6] font-roundedMplus">
+      <div className="h-screen flex flex-col items-center bg-[#9debf6] font-roundedMplus"> {/* Apply background color here */}
         <CalendarHeader />
         <WeekDaysLabels />
         <Month month={currentMonth} currentMonthIndex={monthIndex} />
@@ -66,7 +62,7 @@ const WeekDaysLabels: FC = () => {
   const weekDays = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
   return (
-    <div className="flex justify-center grid grid-cols-7 text-center border-b font-roundedMplus font-bold w-2/3">
+    <div className="flex justify-center grid grid-cols-7 text-center border-b bg-[#9debf6] font-roundedMplus font-bold w-2/3 mt-0 pt-4">
       {weekDays.map((day, index) => (
         <div
           key={day}

--- a/react-app/src/components/CalendarHeader.tsx
+++ b/react-app/src/components/CalendarHeader.tsx
@@ -4,7 +4,6 @@ import 'dayjs/locale/ja';
 import GlobalContext from '../context/GlobalContext';
 import { useNavigate } from 'react-router-dom';
 import { BaseURL } from '../utilities/base_url';
-import '../styles.css';  // カスタムCSSファイルをインポート
 
 dayjs.locale('ja');
 
@@ -82,21 +81,12 @@ const CalendarHeader: FC = () => {
     <div className="flex flex-col">
       <div className="absolute right-[150px] group">
         <img src="/images/icon-account.png" alt="Account" className="w-10 h-10 mt-1 cursor-pointer" onClick={handleUserClick} />
-        <span className="absolute top-12 left-1/2 transform -translate-x-1/2 bg-gray-700 text-white text-xs rounded-md py-1 px-2 opacity-0 group-hover:opacity-100">
-          アカウント情報
-        </span>
       </div>
       <div className="absolute right-[100px] group">
         <img src="/images/icon-settings.png" alt="Settings" className="w-8 h-8 mt-2 cursor-pointer" onClick={handleSettingsClick} />
-        <span className="absolute top-12 left-1/2 transform -translate-x-1/2 bg-gray-700 text-white text-xs rounded-md py-1 px-2 opacity-0 group-hover:opacity-100">
-          運動の設定
-        </span>
       </div>
       <div className="absolute right-[45px] group">
         <img src="/images/icon-signout.png" alt="Signout" className="w-10 h-10 mt-1 cursor-pointer" onClick={handleSignoutClick} />
-        <span className="absolute top-12 left-1/2 transform -translate-x-1/2 bg-gray-700 text-white text-xs rounded-md py-1 px-2 opacity-0 group-hover:opacity-100">
-          サインアウト
-        </span>
       </div>
       <div className="flex justify-between items-center p-0">
         <div className="recommendation-container">

--- a/react-app/src/components/Day.tsx
+++ b/react-app/src/components/Day.tsx
@@ -3,7 +3,6 @@ import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
 import Hanamaru from '../../public/hanamaru.svg';
 
-
 interface DayProps {
   day: dayjs.Dayjs;
   rowIdx: number;
@@ -38,7 +37,7 @@ const Day: FC<DayProps> = ({ day, currentMonthIndex, exerciseDone }) => {
   };
 
   return (
-    <div className="border border-borderDivider flex flex-col rounded-none overflow-hidden">
+    <div className="border border-borderDivider flex flex-col rounded-none overflow-hidden h-30 min-h-[110px]"> {/* 高さを固定、最小高さを設定 */}
       <header className="bg-customSkyblue p-1 flex justify-center">
         <p className={dayNumberClasses}>
           {day.format("D")}

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -1,43 +1,29 @@
 @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700&display=swap');
 
-.icon {
-  @apply relative cursor-pointer;
-}
-
-.icon:hover::after {
-  @apply absolute bottom-10 left-1/2 transform -translate-x-1/2 w-max bg-gray-700 text-white text-xs rounded-md py-1 px-2 opacity-0 group-hover:opacity-100;
-  content: attr(data-tooltip);
-  z-index: 10;
-  opacity: 1;
-}
-
-
+/* Calendar.tsx */
 .grid.grid-cols-7.text-center.border-b.font-roundedMplus {
-  margin-top: 0; 
-  background-color: #9debf6; 
-  padding-top: 1rem; 
-  box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.1); 
+  box-shadow: 0 4px 8px -2px rgba(0, 0, 0, 0.1);
 }
 
-/* 月と年の表示を行なっている部分のスタイルを調整します */
+/* 月と年の表示を行なっている部分のスタイルを調整 */
 .calendar-header .month-and-year {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 0; 
-  padding: 0.5rem 1rem; 
-  background-color: #9debf6; 
+  margin-top: 0;
+  padding: 0.5rem 1rem;
+  background-color: #9debf6;
   position: relative;
 }
 
-/* 月を表示する部分を調整します */
+/* 月を表示する部分を調整 */
 .calendar-header .month-and-year .month {
-  font-size: 1.5rem; 
-  color: #333; 
-  font-weight: bold; 
+  font-size: 1.5rem;
+  color: #333;
+  font-weight: bold;
 }
 
-/* 年を表示する部分を調整します */
+/* 年を表示する部分を調整 */
 .calendar-header .month-and-year .year {
   font-size: 1rem;
 }
@@ -51,12 +37,12 @@
 
 .recommendation-container {
   display: flex;
-  justify-content: center; 
-  align-items: center; 
+  justify-content: center;
+  align-items: center;
   flex-direction: column;
   background: url('/images/icon-recommend.png') no-repeat center center;
   background-size: contain;
-  width: 100%; 
+  width: 100%;
   height: 130px;
   position: relative;
   margin-top: 3em;
@@ -66,47 +52,48 @@
 .recommendation-text,
 .activity-text {
   position: relative;
-  transform: translate(-50%, -50%); 
+  transform: translate(-50%, -50%);
   background: transparent;
   font-weight: bold;
 }
 
 .recommendation-text {
   top: 5%; /* 吹き出し内での上からの位置を指定 */
-  left:0%;
+  left: 0%;
 }
 
 .activity-text {
   top: 15%;
-  left:4%;
-  font-size: 1.3em; 
+  left: 4%;
+  font-size: 1.3em;
   margin-left: 16em;
   margin-bottom: 0.5em;
+  white-space: nowrap; /* 改行を防ぐ */
 }
 
 .recommendation,
 .recommendation-highlight {
   background: transparent;
   font-weight: bold;
-  padding: 0 0.5em; 
+  padding: 0 0.5em;
 }
 
 .triangle-left {
-  width: 30px; 
-  height: 30px; 
-  background-color: #D5FFFF; 
-  clip-path: polygon(0 50%, 100% 0, 100% 100%); /* 左向きの三角形 */
-  position:  relative;
+  width: 30px;
+  height: 30px;
+  background-color: #D5FFFF;
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  position: relative;
   left: 120px;
 }
 
 .triangle-right {
-  width: 30px; 
-  height: 30px; 
-  background-color: #D5FFFF; 
-  clip-path: polygon(100% 50%, 0 0, 0 100%); /* 右向きの三角形 */
-  position:  relative;
-  right:120px;
+  width: 30px;
+  height: 30px;
+  background-color: #D5FFFF;
+  clip-path: polygon(100% 50%, 0 0, 0 100%);
+  position: relative;
+  right: 120px;
 }
 
 body {
@@ -116,7 +103,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color: var(--customBrown, #5f5f5f); 
+  color: var(--customBrown, #5f5f5f);
 }
 
 code {
@@ -129,23 +116,71 @@ code {
   transition: opacity 0.1s;
 }
 
-@media (max-width: 546px) {
+@media (max-width: 650px) {
+  .recommendation-container {
+    transform: scale(1);
+    transform-origin: top center;
+  }
+
   .recommendation-text {
-    top: 7%;
-    left: 0%; 
-    transform: translate(-50%, -10%);
+    font-size: 1.2em;
+    left: -1em; /* 1文字分左に移動 */
   }
 
   .activity-text {
-    top: 18%;
-    left: 50%; 
-    transform: translate(-50%, -25%);
-    font-size: 1.5em;
-    margin-left: auto; 
-    margin-right: auto; 
-    margin-bottom: 1.5em;
-    width: calc(100% - 1em); 
-    text-align: center; 
+    font-size: 1.3em; /* 1.2倍 */
+    margin-left: 16em; /* サイズが変わっても吹き出し内での位置を調整 */
+    white-space: nowrap; /* 改行を防ぐ */
+  }
+
+  .triangle-left {
+    left: 180px;
+  }
+
+  .triangle-right {
+    right: 180px;
+  }
+
+  .grid.grid-cols-7.text-center.border-b.font-roundedMplus {
+    min-width: 440px; 
+  }
+
+  .flex-1.grid {
+    min-width: 440px; /* カレンダー部分の最小幅を設定 */
+  }
+}
+
+@media (max-width: 470px) {
+  .recommendation-container {
+    transform: scale(0.8);
+    transform-origin: top center;
+  }
+
+  .recommendation-text {
+    font-size: 1.2em;
+    left: -1em; /* 1文字分左に移動 */
+  }
+
+  .activity-text {
+    font-size: 1.3em; /* 1.2倍 */
+    margin-left: 16em; /* サイズが変わっても吹き出し内での位置を調整 */
+    white-space: nowrap; /* 改行を防ぐ */
+  }
+
+  .triangle-left {
+    left: 180px;
+  }
+
+  .triangle-right {
+    right: 180px;
+  }
+
+  .grid.grid-cols-7.text-center.border-b.font-roundedMplus {
+    min-width: 370px; 
+  }
+
+  .flex-1.grid {
+    min-width: 370px; /* カレンダー部分の最小幅を設定 */
   }
 }
 


### PR DESCRIPTION
### やったこと
カレンダーページのCSSのみ修正
・横幅400px辺りまで縮めても問題ないことを確認。
・日付ボックスの縦幅は固定（花丸が日付に被らないようにするため）
・前月、翌月の三角の位置を指定（計算式がよくわからなかったので別の方法で指定）
・右上アイコンのツールチップが、レスポンシブ対応に上手く適応できなかったので削除

### 特記事項
CSS以外の要素は変えないように注意したつもりですが、影響がないかご確認ください。